### PR TITLE
 feat: create the Network page for connections request handling

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import {toast, Toaster} from "react-hot-toast";
 import {axiosInstance} from "./lib/axios.ts";
 import {useQuery} from "@tanstack/react-query";
 import NotificationPage from "./pages/NotificationPage.tsx";
+import NetworkPage from "./pages/NetworkPage.tsx";
 
 
 function App() {
@@ -35,6 +36,7 @@ function App() {
             <Route path='/signup' element={!authUser ? <SignupPage /> : <Navigate to={"/"} />} />
             <Route path="/login"element={!authUser ? <LoginPage /> : <Navigate to={"/"} />} />
             <Route path="/notifications"element={authUser ? <NotificationPage /> : <Navigate to={"/login"} />} />
+            <Route path="/network"element={authUser ? <NetworkPage /> : <Navigate to={"/login"} />} />
             <Route path="*" element={<NoMatchPage />} />
         </Routes>
           <Toaster/>

--- a/frontend/src/components/FriendRequest.tsx
+++ b/frontend/src/components/FriendRequest.tsx
@@ -1,0 +1,67 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { axiosInstance } from "../lib/axios";
+import toast from "react-hot-toast";
+import { Link } from "react-router-dom";
+
+const FriendRequest = ({ request }) => {
+    const queryClient = useQueryClient();
+
+    const { mutate: acceptConnectionRequest } = useMutation({
+        mutationFn: (requestId) => axiosInstance.put(`/connections/accept/${requestId}`),
+        onSuccess: () => {
+            toast.success("Connection request accepted");
+            queryClient.invalidateQueries({ queryKey: ["connectionRequests"] });
+        },
+        onError: (error) => {
+            toast.error(error.response.data.error);
+        },
+    });
+
+    const { mutate: rejectConnectionRequest } = useMutation({
+        mutationFn: (requestId) => axiosInstance.put(`/connections/reject/${requestId}`),
+        onSuccess: () => {
+            toast.success("Connection request rejected");
+            queryClient.invalidateQueries({ queryKey: ["connectionRequests"] });
+        },
+        onError: (error) => {
+            toast.error(error.response.data.error);
+        },
+    });
+
+    return (
+        <div className='bg-white rounded-lg shadow p-4 flex items-center justify-between transition-all hover:shadow-md'>
+            <div className='flex items-center gap-4'>
+                <Link to={`/profile/${request.sender.username}`}>
+                    <img
+                        src={request.sender.profilePicture || "/avatar.png"}
+                        alt={request.name}
+                        className='w-16 h-16 rounded-full object-cover'
+                    />
+                </Link>
+
+                <div>
+                    <Link to={`/profile/${request.sender.username}`} className='font-semibold text-lg'>
+                        {request.sender.name}
+                    </Link>
+                    <p className='text-gray-600'>{request.sender.headline}</p>
+                </div>
+            </div>
+
+            <div className='space-x-2'>
+                <button
+                    className='bg-green-900 text-white px-4 py-2 rounded-md hover:bg-primary-dark transition-colors'
+                    onClick={() => acceptConnectionRequest(request._id)}
+                >
+                    Accept
+                </button>
+                <button
+                    className='bg-gray-200 text-gray-800 px-4 py-2 rounded-md hover:bg-gray-300 transition-colors'
+                    onClick={() => rejectConnectionRequest(request._id)}
+                >
+                    Reject
+                </button>
+            </div>
+        </div>
+    );
+};
+export default FriendRequest;

--- a/frontend/src/components/UserCard.tsx
+++ b/frontend/src/components/UserCard.tsx
@@ -1,0 +1,23 @@
+import { Link } from "react-router-dom";
+
+function UserCard({ user, isConnection }) {
+    return (
+        <div className='bg-white rounded-lg shadow p-4 flex flex-col items-center transition-all hover:shadow-md'>
+            <Link to={`/profile/${user.username}`} className='flex flex-col items-center'>
+                <img
+                    src={user.profilePicture || "/avatar.png"}
+                    alt={user.name}
+                    className='w-24 h-24 rounded-full object-cover mb-4'
+                />
+                <h3 className='font-semibold text-lg text-center'>{user.name}</h3>
+            </Link>
+            <p className='text-gray-600 text-center'>{user.headline}</p>
+            <p className='text-sm text-gray-500 mt-2'>{user.connections?.length} connections</p>
+            <button className='mt-4 bg-green-900 text-white px-4 py-2 rounded-md hover:bg-primary-dark transition-colors w-full'>
+                {isConnection ? "Connected" : "Connect"}
+            </button>
+        </div>
+    );
+}
+
+export default UserCard;

--- a/frontend/src/pages/NetworkPage.tsx
+++ b/frontend/src/pages/NetworkPage.tsx
@@ -1,0 +1,66 @@
+import { useQuery } from "@tanstack/react-query";
+import { axiosInstance } from "../lib/axios";
+import Sidebar from "../components/Sidebar";
+import { UserPlus } from "lucide-react";
+import FriendRequest from "../components/FriendRequest";
+import UserCard from "../components/UserCard";
+
+const NetworkPage = () => {
+    const { data: user } = useQuery({ queryKey: ["authUser"] });
+
+    const { data: connectionRequests } = useQuery({
+        queryKey: ["connectionRequests"],
+        queryFn: () => axiosInstance.get("/connections/requests"),
+    });
+
+    const { data: connections } = useQuery({
+        queryKey: ["connections"],
+        queryFn: () => axiosInstance.get("/connections"),
+    });
+
+    return (
+        <div className='grid grid-cols-1 lg:grid-cols-4 gap-6'>
+            <div className='col-span-1 lg:col-span-1'>
+                <Sidebar user={user} />
+            </div>
+            <div className='col-span-1 lg:col-span-3'>
+                <div className='bg-gray-100 rounded-lg shadow p-6 mb-6'>
+                    <h1 className='text-2xl font-bold mb-6'>My Network</h1>
+
+                    {connectionRequests?.data?.length > 0 ? (
+                        <div className='mb-8'>
+                            <h2 className='text-xl font-semibold mb-2'>Connection Request</h2>
+                            <div className='space-y-4'>
+                                {connectionRequests.data.map((request) => (
+                                    <FriendRequest key={request.id} request={request} />
+                                ))}
+                            </div>
+                        </div>
+                    ) : (
+                        <div className='bg-white rounded-lg shadow p-6 text-center mb-6'>
+                            <UserPlus size={48} className='mx-auto text-green-900 mb-4' />
+                            <h3 className='text-xl font-semibold mb-2'>No Connection Requests</h3>
+                            <p className='text-gray-600'>
+                                You don&apos;t have any pending connection requests at the moment.
+                            </p>
+                            <p className='text-gray-600 mt-2'>
+                                Explore suggested connections below to expand your network!
+                            </p>
+                        </div>
+                    )}
+                    {connections?.data?.length > 0 && (
+                        <div className='mb-8'>
+                            <h2 className='text-xl font-semibold mb-4'>My Connections</h2>
+                            <div className='grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4'>
+                                {connections.data.map((connection) => (
+                                    <UserCard key={connection._id} user={connection} isConnection={true} />
+                                ))}
+                            </div>
+                        </div>
+                    )}
+                </div>
+            </div>
+        </div>
+    );
+};
+export default NetworkPage;


### PR DESCRIPTION
This pull request introduces a new `NetworkPage` feature to the frontend application, enabling users to view and manage their connections and connection requests. It also adds reusable components for displaying user cards and handling friend requests. Below is a breakdown of the most important changes:

### New `NetworkPage` Feature:

* **`frontend/src/pages/NetworkPage.tsx`:** Added a new page that displays the user's connection requests and connections. It uses `react-query` to fetch data and integrates the `FriendRequest` and `UserCard` components for rendering.
* **`frontend/src/App.tsx`:** Updated the routing to include the `/network` route, which renders the `NetworkPage` for authenticated users.

### Reusable Components:

* **`frontend/src/components/FriendRequest.tsx`:** Added a component to handle individual connection requests, allowing users to accept or reject requests with visual feedback via `react-hot-toast`.
* **`frontend/src/components/UserCard.tsx`:** Added a component to display user profiles in a card format, including connection status and an option to connect.

### Codebase Enhancements:

* **`frontend/src/App.tsx`:** Imported the new `NetworkPage` component to integrate it into the application.