### PR TITLE
 feat: now we can travel from the notification page to a single post …

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,6 +10,7 @@ import {axiosInstance} from "./lib/axios.ts";
 import {useQuery} from "@tanstack/react-query";
 import NotificationPage from "./pages/NotificationPage.tsx";
 import NetworkPage from "./pages/NetworkPage.tsx";
+import PostPage from "./pages/PostPage.tsx";
 
 
 function App() {
@@ -37,6 +38,7 @@ function App() {
             <Route path="/login"element={!authUser ? <LoginPage /> : <Navigate to={"/"} />} />
             <Route path="/notifications"element={authUser ? <NotificationPage /> : <Navigate to={"/login"} />} />
             <Route path="/network"element={authUser ? <NetworkPage /> : <Navigate to={"/login"} />} />
+            <Route path='/post/:postId' element={authUser ? <PostPage /> : <Navigate to={"/login"} />} />
             <Route path="*" element={<NoMatchPage />} />
         </Routes>
           <Toaster/>

--- a/frontend/src/pages/PostPage.tsx
+++ b/frontend/src/pages/PostPage.tsx
@@ -1,0 +1,31 @@
+import { useQuery } from "@tanstack/react-query";
+import { useParams } from "react-router-dom";
+import { axiosInstance } from "../lib/axios";
+import Sidebar from "../components/Sidebar";
+import Post from "../components/Post";
+
+const PostPage = () => {
+    const { postId } = useParams();
+    const { data: authUser } = useQuery({ queryKey: ["authUser"] });
+
+    const { data: post, isLoading } = useQuery({
+        queryKey: ["post", postId],
+        queryFn: () => axiosInstance.get(`/posts/${postId}`),
+    });
+
+    if (isLoading) return <div>Loading post...</div>;
+    if (!post?.data) return <div>Post not found</div>;
+
+    return (
+        <div className='grid grid-cols-1 lg:grid-cols-4 gap-6'>
+            <div className='hidden lg:block lg:col-span-1'>
+                <Sidebar user={authUser} />
+            </div>
+
+            <div className='col-span-1 lg:col-span-3'>
+                <Post post={post.data} />
+            </div>
+        </div>
+    );
+};
+export default PostPage;


### PR DESCRIPTION
This pull request introduces a new `PostPage` component and integrates it into the application routing. The changes primarily focus on adding functionality for viewing individual posts and ensuring proper routing and data fetching for the new page.

### New feature: PostPage component

* [`frontend/src/pages/PostPage.tsx`](diffhunk://#diff-1ceea336f8defe5393b4f393c5fd7f18b9d70b6497b5809febf47e228b8660e1R1-R31): Added a new `PostPage` component that fetches and displays individual posts using `useQuery`. Includes a sidebar for authenticated users and a loading state for better user experience.

### Routing updates

* [`frontend/src/App.tsx`](diffhunk://#diff-e56cb91573ddb6a97ecd071925fe26504bb5a65f921dc64c63e534162950e1ebR13): Imported the new `PostPage` component and added a route for viewing individual posts (`/post/:postId`). Ensures that users must be authenticated to access this route. [[1]](diffhunk://#diff-e56cb91573ddb6a97ecd071925fe26504bb5a65f921dc64c63e534162950e1ebR13) [[2]](diffhunk://#diff-e56cb91573ddb6a97ecd071925fe26504bb5a65f921dc64c63e534162950e1ebR41)…page to interact with the Post